### PR TITLE
単体画像の投稿機能を実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Image;
 use App\Models\Post;
 # PostRequestは、バリデーションのために生成したクラス
 use App\Http\Requests\PostRequest;
+use Cloudinary;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -21,11 +23,17 @@ class PostController extends Controller
         return view('posts.create')->with([ 'post' => $post]);
     }
     # 新規投稿を保存するメソッド
-    public function store(PostRequest $request, Post $post)
+    public function store(Image $image, Post $post, PostRequest $request)
     {
-        $input = $request->input('post');
-        $input['user_id'] = Auth::id();
-        $post->fill($input)->save();
+        $inputPost = $request->input('post');
+        $inputPost['user_id'] = Auth::id();
+        $post->fill($inputPost)->save();
+        
+        $uploadedFileUrl['image_path'] = Cloudinary::uploadFile($request->file('image')
+            ->getRealPath())->getSecurePath();
+        $uploadedFileUrl['post_id'] = $post->id;
+        $image->fill($uploadedFileUrl)->save();
+        
         # redirectメソッドにURLを渡す
         return redirect('/posts');
     }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -10,6 +10,11 @@ class Image extends Model
 {
     use HasFactory;
     
+    protected $fillable = [
+        'image_path',
+        'post_id',
+    ];
+    
     # 1対多（逆）の定義
     public function post(): BelongsTo
     {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "cloudinary-labs/cloudinary-laravel": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c83b06f5f51dc9e949582b2409ddc64b",
+    "content-hash": "33e054e3906de851358600b871d24b33",
     "packages": [
         {
             "name": "brick/math",
@@ -129,6 +129,202 @@
                 }
             ],
             "time": "2023-12-11T17:09:12+00:00"
+        },
+        {
+            "name": "cloudinary-labs/cloudinary-laravel",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary-devs/cloudinary-laravel.git",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary-devs/cloudinary-laravel/zipball/f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/cloudinary_php": "^2.0",
+                "ext-json": "*",
+                "illuminate/support": "~6|~7|~8|^9.0|^10.0",
+                "php": "^8.0.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/testbench": "~4|~5|~6|^7.0",
+                "phpunit/phpunit": "^8.0|^9.5.10",
+                "sempro/phpunit-pretty-print": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "CloudinaryLabs\\CloudinaryLaravel\\CloudinaryServiceProvider"
+                    ],
+                    "aliases": {
+                        "Cloudinary": "CloudinaryLabs\\CloudinaryLaravel\\Facades\\Cloudinary"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "CloudinaryLabs\\CloudinaryLaravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prosper Otemuyiwa",
+                    "email": "prosperotemuyiwa@gmail.com",
+                    "homepage": "https://github.com/unicodeveloper"
+                }
+            ],
+            "description": "A Laravel Cloudinary Package",
+            "homepage": "https://github.com/cloudinary-labs/cloudinary-laravel",
+            "keywords": [
+                "File Transformations",
+                "Media management",
+                "cloudinary",
+                "cloudinary-laravel",
+                "file uploads",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/cloudinary-devs/cloudinary-laravel/issues",
+                "source": "https://github.com/cloudinary-devs/cloudinary-laravel/tree/2.0.3"
+            },
+            "time": "2023-03-01T15:07:23+00:00"
+        },
+        {
+            "name": "cloudinary/cloudinary_php",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/cloudinary_php.git",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/cloudinary_php/zipball/57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/transformation-builder-sdk": "^1",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
+                "guzzlehttp/promises": "^1.5.3|^2.0",
+                "guzzlehttp/psr7": "^1.9.1|^2.5",
+                "monolog/monolog": "^1|^2|^3",
+                "php": ">=5.6.0",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/cloudinary_php/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP SDK",
+            "homepage": "https://github.com/cloudinary/cloudinary_php",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/cloudinary_php/issues"
+            },
+            "time": "2023-12-03T13:57:09+00:00"
+        },
+        {
+            "name": "cloudinary/transformation-builder-sdk",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/php-transformation-builder-sdk.git",
+                "reference": "a88d3554ddffec3ecd2086bcbd1484757f6b78d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/php-transformation-builder-sdk/zipball/a88d3554ddffec3ecd2086bcbd1484757f6b78d8",
+                "reference": "a88d3554ddffec3ecd2086bcbd1484757f6b78d8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP Transformation Builder SDK",
+            "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/php-transformation-builder-sdk/issues"
+            },
+            "time": "2024-01-07T13:57:38+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Laravel Cloudinary package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | An HTTP or HTTPS URL to notify your application (a webhook) when the process of uploads, deletes, and any API
+    | that accepts notification_url has completed.
+    |
+    |
+    */
+    # LOUDINARY_NOTIFICATION_URLは、オプションである。
+    'notification_url' => env('CLOUDINARY_NOTIFICATION_URL'),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Cloudinary settings. Cloudinary is a cloud hosted
+    | media management service for all file uploads, storage, delivery and transformation needs.
+    |
+    |
+    */
+    'cloud_url' => env('CLOUDINARY_URL'),
+
+    /**
+     * Upload Preset From Cloudinary Dashboard
+     *
+     */
+    # CLOUDINARY_UPLOAD_PRESET=は、オプションである。
+    'upload_preset' => env('CLOUDINARY_UPLOAD_PRESET'),
+
+];

--- a/database/migrations/2020_06_14_000001_create_media_table.php
+++ b/database/migrations/2020_06_14_000001_create_media_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMediaTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->morphs('medially');
+            $table->text('file_url');
+            $table->string('file_name');
+            $table->string('file_type')->nullable();
+            $table->unsignedBigInteger('size');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('media');
+    }
+}

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -7,7 +7,7 @@
     <!-- 作成フォーム-->
     <h1>投稿作成</h1>
     <div class="post_create">
-        <form action="/posts" method="post">
+        <form action="/posts" method="post" enctype="multipart/form-data">
             @include('posts.form')
             <input type="submit" value="保存" /></br>
             <a href="{{ route('post_index') }}">タイムラインへ戻る</a>

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -1,8 +1,14 @@
 @csrf
 <h2>本文</h2>
+<div class="post_body">
     @if($post->doesntExist())
         <textarea type="text" name="post[body]" placeholder="今日はどんな天気でしたか？"></textarea><br/>
     @else
         <textarea type="text" name="post[body]" placeholder="今日はどんな天気でしたか？">{{ old('body', $post) }}</textarea><br/>
     @endif
         <p class="body_error red">{{ $errors->first('post.body') }}</p>
+</div>
+<div class="post_image">
+    <input type="file" name="image" />
+</div>
+        

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -9,7 +9,8 @@
         <div class="post">
             <h2 class="name">{{ $post->user->name }}</h2>
             <h2>本文</h2>
-            <h2>{{ $post->body }}</h2>
+            <p>{{ $post->body }}</p>
+            <p>{{ $post->images->first()->image_path }}</p>
         </div>
     </article>
     

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
+# 以下、コントローラ名で昇順
 
 # 投稿関連機能
 Route::controller(PostController::class)->group(function() {


### PR DESCRIPTION
単体画像の投稿機能を実装した。

具体的には、
以前の投稿機能に加え、画像を投稿する機能を実装した。
ただし、投稿できる画像は、1つだけである。
複数の画像を投稿することはできない。

また、実装する際には、ファイルを保存するために外部サービスを利用した。
そのサービスは、Cloudinaryである。

現状、クライアント側にはファイルパスを表示させている。
プレビュー表示の実装はJavaScriptが必要なため後回しにする。